### PR TITLE
Update Spring Cloud AWS version to one that is publicly accessible 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring-cloud-aws-version>1.0.0.BUILD-SNAPSHOT</spring-cloud-aws-version>
+        <spring-cloud-aws-version>1.0.1.RELEASE</spring-cloud-aws-version>
         <java.version>1.7</java.version>
     </properties>
 


### PR DESCRIPTION
... so the sample works 'out of the box'.

The original version `1.0.0.BUILD-SNAPSHOT` isn't in maven central and it might be off-putting for people wanting to play with this sample if they discover that the artefact isn't publicly available. Bumped it to the latest release version at the time of writing. 
