### PR TITLE
Correct region to avoid exception upon startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ An example file would look like this
 
 	cloud.aws.credentials.accessKey=ilaugsjdlkahgsdlaksdhg
     cloud.aws.credentials.secretKey=aöksjdhöadjs,höalsdhjköalsdjhasd+
-    cloud.aws.region.static=EU_WEST_1
+    cloud.aws.region.static=eu-west-1
     cloud.aws.stack.name=AwsSampleStack
     cloud.aws.rds.RdsInstance.password=someVerySecretPassword
 


### PR DESCRIPTION
`README.me` gives an example region of `EU_WEST_1` however this causes the following exception upon startup:

```
Caused by: java.lang.IllegalArgumentException: The region 'EU_WEST_1' is not a valid region!
  at org.springframework.util.Assert.notNull(Assert.java:112)
  at org.springframework.cloud.aws.core.region.StaticRegionProvider.<init>(StaticRegionProvider.java:44)
  at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
  at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
  at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
  at java.lang.reflect.Constructor.newInstance(Constructor.java:408)
  at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:147)
  ... 59 more
```

`StaticRegionProvider` uses `RegionUtils` which, by default, takes its regions from `/com/amazonaws/regions/regions.xml`. In here the correct region name is `eu-west-1`.

Updated `README.md` to reflect this and have tested the change locally with success.  
